### PR TITLE
Increase `check-deps` timeout to 20 minutes

### DIFF
--- a/.github/workflows/check-deps.yml
+++ b/.github/workflows/check-deps.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       java-version: "8"
       notify-ocd3: true
+      check-deps-timeout-minutes: 20
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}


### PR DESCRIPTION
Updated the `check-deps-timeout-minutes` parameter in `check-deps` GA workflow to 20 mins(default is 10 mins). This change ensures that the dependency check process has sufficient time to complete.