### PR TITLE
OZ-678: Update `ozone/` to `configs/` for serving frontend configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ settings.xml
 .idea/**/dynamic.xml
 .idea/**/uiDesigner.xml
 .idea/**/dbnavigator.xml
+.idea
 
 # Gradle
 .idea/**/gradle.xml

--- a/configs/openmrs/frontend_config/ozone-frontend-config.json
+++ b/configs/openmrs/frontend_config/ozone-frontend-config.json
@@ -15,19 +15,19 @@
       }
     ],
     "logo": {
-      "src": "ozone/ozone_logo_white.svg",
+      "src": "configs/ozone_logo_white.svg",
       "alt": "ozone-logo"
     }
   },
   "@openmrs/esm-login-app": {
     "logo": {
-      "src": "ozone/ozone_logo_color.svg",
+      "src": "configs/ozone_logo_color.svg",
       "alt": "ozone-logo"
     }
   },
   "@openmrs/esm-patient-chart-app": {
     "logo": {
-      "src": "ozone/ozone_logo_white.svg",
+      "src": "configs/ozone_logo_white.svg",
       "alt": "ozone-logo"
     },
     "Display conditions": {


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/jira/software/c/projects/OZ/issues/OZ-698

This PR updates `ozone/` to `configs/` because frontend assets/configs is now served at `/configs`