### PR TITLE
HSC-335: Add + configure `openmrs-module-orderexpansion` to support material ordering

### DIFF
--- a/configs/openmrs/initializer_config/ordertypes/order_types.csv
+++ b/configs/openmrs/initializer_config/ordertypes/order_types.csv
@@ -5,3 +5,4 @@ ef83e09d-8885-4f12-be6b-06a80aa62972,,Product,An order for a product,org.openmrs
 f8ae333e-9d1a-423e-a6a8-c3a0687ebcf2,,Lab Order,An order for laboratory tests,org.openmrs.Order,,LabTest;LabSet
 52a447d3-a64a-11e3-9aeb-50e549534c5e,,Test Order,Order type for test orders,org.openmrs.TestOrder,,Test
 7af35686-b7a6-45f0-818d-529ff37b0514,,Misc Order,Order type for test orders,org.openmrs.Order,,Misc
+14a1032d-7b7e-4067-a3f1-576cb4f4422e,,Medical Supply Order,Order type for medical supplies,org.openmrs.module.orderexpansion.api.model.MedicalSupplyOrder,,Material

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <!-- Classifier for the dependency report artifact -->
     <dependencyReportClassifier>dependencies</dependencyReportClassifier>
     <openmrsERPVersion>2.1.0-SNAPSHOT</openmrsERPVersion>
+    <orderExpansionVersion>1.0.0-SNAPSHOT</orderExpansionVersion>
   </properties>
 
   <dependencies>
@@ -43,7 +44,7 @@
     <dependency>
       <groupId>org.openmrs.module</groupId>
       <artifactId>orderexpansion-omod</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>${orderExpansionVersion}</version>
     </dependency>
     <!-- TODO: Add any implementation-specific dependencies -->
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>erp-omod</artifactId>
       <version>${openmrsERPVersion}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openmrs.module</groupId>
+      <artifactId>orderexpansion-omod</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </dependency>
     <!-- TODO: Add any implementation-specific dependencies -->
   </dependencies>
 


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/HSC-335

This PR adds and configures `orderexpansion` OpenMRS module to support material ordering.