### PR TITLE
(feat) Add ward app to the Ozone Haiti Distro

### DIFF
--- a/configs/openmrs/frontend_assembly/spa-assemble-config.json
+++ b/configs/openmrs/frontend_assembly/spa-assemble-config.json
@@ -1,7 +1,8 @@
 {
   "frontendModules": {
     "@mekomsolutions/esm-patient-billing-status-app": "next",
-    "@mekomsolutions/esm-patient-medical-supply-orders-app": "next"
+    "@mekomsolutions/esm-patient-medical-supply-orders-app": "next",
+    "@openmrs/esm-ward-app": "next"
   },
   "__comment": "Haiti Overrides",
   "frontendModuleExcludes": []


### PR DESCRIPTION
Ward app was not included as part of the O3 `3.2.1` release.