### PR TITLE
HSC-350: Include `initializer_config.json` so Odoo can load `auth_providers`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
                   <directory>${project.build.directory}/ozone</directory>
                   <includes>
                     <include>distro/configs/odoo/initializer_config/auth_providers/**</include>
+                    <include>distro/configs/odoo/initializer_config/initializer_config.json</include>
                   </includes>
                 </resource>
               </resources>


### PR DESCRIPTION
This should fix the issue with Auth providers not being loaded by Odoo  initializer in HSC