### PR TITLE
HSC-344: Set `esm-patient-search-app` to `8.3.2-pre.5004`

### DIFF
--- a/configs/openmrs/frontend_assembly/spa-assemble-config.json
+++ b/configs/openmrs/frontend_assembly/spa-assemble-config.json
@@ -9,6 +9,7 @@
     "@openmrs/esm-patient-tests-app": "9.2.1-pre.6905",
     "@openmrs/esm-patient-medications-app": "9.2.1-pre.6905",
     "@openmrs/esm-patient-forms-app": "9.2.1-pre.6905",
+    "@openmrs/esm-patient-search-app": "8.3.2-pre.5004",
     "@openmrs/esm-form-engine-app": "9.2.1-pre.6905",
     "@openmrs/esm-home-app": "5.6.2-pre.534"
   },


### PR DESCRIPTION
This PR fixes issue with searching patient using phone number in Ozone Distro HSC.