### PR TITLE
HSC-437: Update 'esm-patient-allergies-app' to 9.2.1

### DIFF
--- a/configs/openmrs/frontend_assembly/spa-assemble-config.json
+++ b/configs/openmrs/frontend_assembly/spa-assemble-config.json
@@ -10,7 +10,8 @@
     "@openmrs/esm-patient-medications-app": "9.2.1-pre.6905",
     "@openmrs/esm-patient-forms-app": "9.2.1-pre.6905",
     "@openmrs/esm-form-engine-app": "9.2.1-pre.6905",
-    "@openmrs/esm-home-app": "5.6.2-pre.534"
+    "@openmrs/esm-home-app": "5.6.2-pre.534",
+    "@openmrs/esm-patient-allergies-app": "9.2.1"
   },
   "__comment": "Haiti Overrides",
   "frontendModuleExcludes": []


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/HSC-437

Fixes the inability to record allergies when in non-english locales:


https://github.com/user-attachments/assets/77d3a135-a567-4949-b88c-f8cca125a585



