### PR TITLE
HSC-438: Exclude Attachements, Laboratory and Services Queues ESMs

### DIFF
--- a/configs/openmrs/frontend_assembly/spa-assemble-config.json
+++ b/configs/openmrs/frontend_assembly/spa-assemble-config.json
@@ -14,5 +14,10 @@
     "@openmrs/esm-patient-allergies-app": "9.2.1"
   },
   "__comment": "Haiti Overrides",
-  "frontendModuleExcludes": []
+  "frontendModuleExcludes": [
+    "@openmrs/esm-service-queues-app",
+    "@openmrs/esm-appointments-app",
+    "@openmrs/esm-laboratory-app",
+    "@openmrs/esm-patient-programs-app"
+  ]
 }


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/HSC-438

<img width="993" alt="Screenshot 2025-03-13 at 13 09 35" src="https://github.com/user-attachments/assets/b0913d96-2248-42c2-82c9-a48c00fe59e2" />

Attachements, Service Queues and Laboratory pages not present.
Attachements widget on Home page removed.
