### PR TITLE
HSC-431: Do not create the 'Tablet' dosage unit

### DIFF
--- a/configs/openmrs/initializer_config/concepts/dosage_forms.csv
+++ b/configs/openmrs/initializer_config/concepts/dosage_forms.csv
@@ -1,5 +1,4 @@
 Uuid,Void/Retire,Fully specified name:en,Fully specified name:fr,Short name:en,Short name:fr,Data class,Data Type,_version:1,_order:60
-fdbe907b-6abc-41dc-9599-2d84105e4063,,Tablet,Comprime,Tablet,Comprime,Misc,N/A,,
 90a3f930-2eef-4a2e-8427-5359607c7b13,,Solution,Solution,Solution,Solution,Misc,N/A,,
 0689bb6e-9371-4a0f-ad1c-63c135b1714d,,Cream,Creme,Cream,Creme,Misc,N/A,,
 658c1b9c-51c8-4734-8bf2-80e750c7889f,,Inhalable,Inhalable,Inhalable,Inhalable,Misc,N/A,,


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/HSC-431

Dosage unit/form with UUID `fdbe907b-6abc-41dc-9599-2d84105e4063` should not be used. (Drug orders in prod data are referring to another 'Tablets' units ('Tablet(s), uuid: `6fbbb779-94ca-4d83-8e02-8a559627b9fb`).

Removing it from `dosage_forms.csv`.

Tested locally.