### PR TITLE
HSC-473: Set visits.assignmentHandler to org.openmrs.api.handler.ExistingVisitAssignmentHandler

### DIFF
--- a/configs/openmrs/initializer_config/globalproperties/ipd-properties.xml
+++ b/configs/openmrs/initializer_config/globalproperties/ipd-properties.xml
@@ -1,0 +1,12 @@
+<config>
+    <globalProperties>
+        <globalProperty>
+            <property>visits.assignmentHandler</property>
+            <value>org.openmrs.api.handler.ExistingVisitAssignmentHandler</value>
+        </globalProperty>
+        <globalProperty>
+            <property>visits.allowOverlappingVisits</property>
+            <value>false</value>
+        </globalProperty>
+    </globalProperties>
+</config>


### PR DESCRIPTION
As required for the Ward app to work in multi-location configuration, the `visits.assignmentHandler` property needs to be set to `org.openmrs.api.handler.ExistingVisitAssignmentHandler`.

https://mekomsolutions.atlassian.net/browse/HSC-473

Slack conversation: https://mekomsolutions.slack.com/archives/G421UNF5L/p1747987873331509
